### PR TITLE
Update jwt payload

### DIFF
--- a/app/api/routers/authentication.py
+++ b/app/api/routers/authentication.py
@@ -10,7 +10,7 @@ from pydantic import EmailStr
 
 from app.core.errors import ResourceNotFoundError
 from app.core.repositories import UsersRepository
-from app.core.schemas import TokenCreate, Token, UserCreate, UserRead
+from app.core.schemas import JWTPayload, TokenCreate, Token, UserCreate, UserRead
 from app.core.services import CodeService, JWTService
 from app.core.tasks import SendCodeProducer
 
@@ -65,7 +65,7 @@ def retrieve_token(
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST, detail="Invalid access code"
         )
-    jwt = jwt_service.generate_token({"user_id": user.id})
+    jwt = jwt_service.generate_token(JWTPayload(user_id=user.id))
     return Token(access_token=jwt)
 
 

--- a/app/core/schemas/__init__.py
+++ b/app/core/schemas/__init__.py
@@ -1,3 +1,4 @@
 from .authentication import TokenCreate, Token
+from .jwt import JWTPayload
 from .transactional import Transactional, TransactionalSchema
 from .user import UserCreate, UserRead, UserUpdate

--- a/app/core/schemas/jwt.py
+++ b/app/core/schemas/jwt.py
@@ -1,0 +1,12 @@
+from time import time
+from typing import Optional
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+
+class JWTPayload(BaseModel):
+    exp: Optional[float] = None
+    jti: str = str(uuid4())
+    nbf: float = time()
+    user_id: int

--- a/app/core/services/jwt.py
+++ b/app/core/services/jwt.py
@@ -1,24 +1,29 @@
-from typing import Dict
+from time import time
 
 from jwt import decode, encode
 
 from app.settings import Settings
+from app.core.schemas import JWTPayload
 
 
 class JWTService:
     def __init__(self, settings: Settings):
         self._settings = settings
 
-    def generate_token(self, payload: Dict) -> str:
+    def generate_token(self, payload: JWTPayload) -> str:
+        if payload.exp is None:
+            payload.exp = time() + self._settings.JWT_EXPIRATION_SECONDS
         return encode(
-            payload=payload,
+            payload=payload.dict(by_alias=True),
             key=self._settings.JWT_PRIVATE_KEY,
             algorithm=self._settings.JWT_ALGORITHM,
         ).decode(encoding="utf-8")
 
-    def verify_token(self, token: str) -> Dict:
-        return decode(
-            jwt=token,
-            key=self._settings.JWT_PUBLIC_KEY,
-            algorithms=[self._settings.JWT_ALGORITHM],
+    def verify_token(self, token: str) -> JWTPayload:
+        return JWTPayload(
+            **decode(
+                jwt=token,
+                key=self._settings.JWT_PUBLIC_KEY,
+                algorithms=[self._settings.JWT_ALGORITHM],
+            )
         )

--- a/app/settings.py
+++ b/app/settings.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     JWT_ALGORITHM: str = "RS256"
     JWT_PUBLIC_KEY: bytes
     JWT_PRIVATE_KEY: bytes
+    JWT_EXPIRATION_SECONDS: int = 300
     ACCESS_CODE_LENGTH: int = 6
     ACCESS_CODE_EXPIRATION_SECONDS: int = 300
 


### PR DESCRIPTION
## What

This PR updates the jwt payload schema to include claims such as `exp`, `nbf`, and `jti` to improve security and stop allowing JWTs without expiration.