### PR TITLE
Add refresh token

### DIFF
--- a/app/api/dependencies/__init__.py
+++ b/app/api/dependencies/__init__.py
@@ -8,6 +8,7 @@ from .errors import (
 from .repositories import (
     db_session,
     delete_user_by_id,
+    find_user_by_email,
     find_user_by_id,
     update_user_by_id,
     users_repository,

--- a/app/api/dependencies/__init__.py
+++ b/app/api/dependencies/__init__.py
@@ -13,7 +13,7 @@ from .repositories import (
     update_user_by_id,
     users_repository,
 )
-from .security import WithRoles, access_token, current_user
+from .security import WithRoles, access_code_user, access_token, current_user
 from .services import (
     access_code_service,
     cache_adapter,

--- a/app/api/dependencies/__init__.py
+++ b/app/api/dependencies/__init__.py
@@ -13,7 +13,13 @@ from .repositories import (
     update_user_by_id,
     users_repository,
 )
-from .security import WithRoles, access_code_user, access_token, current_user
+from .security import (
+    WithRoles,
+    access_code_user,
+    access_token,
+    current_user,
+    refresh_token,
+)
 from .services import (
     access_code_service,
     cache_adapter,

--- a/app/api/dependencies/repositories.py
+++ b/app/api/dependencies/repositories.py
@@ -33,6 +33,13 @@ def find_user_by_id(user_id: int, users_repository: UsersRepository) -> User:
         raise_user_not_found()
 
 
+def find_user_by_email(email: str, users_repository: UsersRepository) -> User:
+    try:
+        return users_repository.find_by_email(email)
+    except ResourceNotFoundError:
+        raise_user_not_found()
+
+
 def update_user_by_id(
     user_id: int, user: Dict, users_repository: UsersRepository
 ) -> User:

--- a/app/api/routers/authentication.py
+++ b/app/api/routers/authentication.py
@@ -6,8 +6,8 @@ from app.core.repositories import UsersRepository
 from app.core.schemas import (
     AccessCodeCreate,
     AccessToken,
-    AccessTokenCreate,
     AccessTokenPayload,
+    RefreshTokenCreate,
     UserCreate,
 )
 from app.core.services import AccessCodeService, JWTService
@@ -51,7 +51,7 @@ def generate_access_code(
     status_code=HTTP_202_ACCEPTED,
 )
 def generate_access_token(
-    body: AccessTokenCreate,
+    body: RefreshTokenCreate,
     settings: Settings = Depends(get_settings),
     users: UsersRepository = Depends(users_repository),
     access_code_service: AccessCodeService = Depends(access_code_service),

--- a/app/api/routers/authentication.py
+++ b/app/api/routers/authentication.py
@@ -31,7 +31,7 @@ router = APIRouter()
 
 
 @router.post("/authentication/code", status_code=HTTP_201_CREATED)
-def generate_access_code(
+def send_access_code(
     body: AccessCodeCreate,
     access_code_service: AccessCodeService = Depends(access_code_service),
     producer: SendCodeProducer = Depends(send_code_producer),
@@ -50,7 +50,7 @@ def generate_access_code(
 @router.post(
     "/authentication/token", response_model=AccessToken, status_code=HTTP_201_CREATED,
 )
-def generate_refresh_token(
+def create_user_session(
     response: Response,
     access_code_user: User = Depends(access_code_user),
     jwt_service: JWTService = Depends(jwt_service),
@@ -78,7 +78,7 @@ def generate_refresh_token(
 @router.get(
     "/authentication/token", response_model=AccessToken, status_code=HTTP_200_OK,
 )
-def generate_access_token(
+def get_fresh_token(
     jwt_service: JWTService = Depends(jwt_service),
     refresh_token: RefreshTokenPayload = Depends(refresh_token),
     session_service: SessionService = Depends(session_service),

--- a/app/core/schemas/__init__.py
+++ b/app/core/schemas/__init__.py
@@ -1,4 +1,4 @@
-from .authentication import AccessCodeCreate, AccessToken, AccessTokenCreate
+from .authentication import AccessCodeCreate, AccessToken, RefreshTokenCreate
 from .jwt import AccessTokenPayload, BaseJWTPayload
 from .transactional import Transactional, TransactionalSchema
 from .user import UserCreate, UserRead, UserUpdate

--- a/app/core/schemas/__init__.py
+++ b/app/core/schemas/__init__.py
@@ -1,4 +1,4 @@
 from .authentication import AccessCodeCreate, AccessToken, RefreshTokenCreate
-from .jwt import AccessTokenPayload, BaseJWTPayload
+from .jwt import AccessTokenPayload, BaseJWTPayload, RefreshTokenPayload
 from .transactional import Transactional, TransactionalSchema
 from .user import UserCreate, UserRead, UserUpdate

--- a/app/core/schemas/authentication.py
+++ b/app/core/schemas/authentication.py
@@ -6,7 +6,7 @@ class AccessCodeCreate(BaseModel):
     create_user: bool = False
 
 
-class AccessTokenCreate(BaseModel):
+class RefreshTokenCreate(BaseModel):
     email: EmailStr
     code: str
 

--- a/app/core/schemas/jwt.py
+++ b/app/core/schemas/jwt.py
@@ -3,9 +3,17 @@ from time import time
 from typing import List
 from uuid import uuid4
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.core.models import User, UserRoles
+
+
+def uuid_str() -> str:
+    return str(uuid4())
+
+
+def time_int() -> int:
+    return int(time())
 
 
 class TokenType(str, Enum):
@@ -15,8 +23,8 @@ class TokenType(str, Enum):
 
 class BaseJWTPayload(BaseModel):
     exp: int
-    jti: str = str(uuid4())
-    nbf: int = int(time())
+    jti: str = Field(default_factory=uuid_str)
+    nbf: int = Field(default_factory=time_int)
     token_type: TokenType
 
     @staticmethod

--- a/app/core/schemas/jwt.py
+++ b/app/core/schemas/jwt.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from time import time
 from typing import List
 from uuid import uuid4
@@ -7,10 +8,15 @@ from pydantic import BaseModel
 from app.core.models import UserRoles
 
 
+class TokenType(str, Enum):
+    ACCESS = "access"
+
+
 class BaseJWTPayload(BaseModel):
     exp: float
     jti: str = str(uuid4())
     nbf: float = time()
+    token_type: TokenType
 
     @staticmethod
     def calc_exp(seconds_from_now: int = 0) -> float:
@@ -19,4 +25,5 @@ class BaseJWTPayload(BaseModel):
 
 class AccessTokenPayload(BaseJWTPayload):
     roles: List[UserRoles]
+    token_type: TokenType = TokenType.ACCESS
     user_id: int

--- a/app/core/schemas/jwt.py
+++ b/app/core/schemas/jwt.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
-from app.core.models import UserRoles
+from app.core.models import User, UserRoles
 
 
 class TokenType(str, Enum):
@@ -26,10 +26,26 @@ class BaseJWTPayload(BaseModel):
 
 class AccessTokenPayload(BaseJWTPayload):
     roles: List[UserRoles]
+    sid: str
     token_type: TokenType = TokenType.ACCESS
     user_id: int
+
+    @staticmethod
+    def from_info(expiration_seconds: int, session_id: str, user: User):
+        return AccessTokenPayload(
+            exp=AccessTokenPayload.calc_exp(expiration_seconds),
+            roles=user.roles,
+            sid=session_id,
+            user_id=user.id,
+        )
 
 
 class RefreshTokenPayload(BaseJWTPayload):
     jti = str
     token_type: TokenType = TokenType.REFRESH
+
+    @staticmethod
+    def from_info(expiration_seconds: int, session_id: str):
+        return RefreshTokenPayload(
+            exp=RefreshTokenPayload.calc_exp(expiration_seconds), jti=session_id,
+        )

--- a/app/core/schemas/jwt.py
+++ b/app/core/schemas/jwt.py
@@ -13,14 +13,14 @@ class TokenType(str, Enum):
 
 
 class BaseJWTPayload(BaseModel):
-    exp: float
+    exp: int
     jti: str = str(uuid4())
-    nbf: float = time()
+    nbf: int = int(time())
     token_type: TokenType
 
     @staticmethod
-    def calc_exp(seconds_from_now: int = 0) -> float:
-        return time() + seconds_from_now
+    def calc_exp(seconds_from_now: int = 0) -> int:
+        return int(time()) + seconds_from_now
 
 
 class AccessTokenPayload(BaseJWTPayload):

--- a/app/core/schemas/jwt.py
+++ b/app/core/schemas/jwt.py
@@ -10,6 +10,7 @@ from app.core.models import UserRoles
 
 class TokenType(str, Enum):
     ACCESS = "access"
+    REFRESH = "refresh"
 
 
 class BaseJWTPayload(BaseModel):
@@ -27,3 +28,8 @@ class AccessTokenPayload(BaseJWTPayload):
     roles: List[UserRoles]
     token_type: TokenType = TokenType.ACCESS
     user_id: int
+
+
+class RefreshTokenPayload(BaseJWTPayload):
+    jti = str
+    token_type: TokenType = TokenType.REFRESH

--- a/tests/integration/routers/conftest.py
+++ b/tests/integration/routers/conftest.py
@@ -5,7 +5,7 @@ from starlette.testclient import TestClient
 
 from app.api import create_api
 from app.api.dependencies import send_code_producer
-from app.core.services import JWTService
+from app.core.services import JWTService, SessionService
 from app.settings import get_settings
 
 mock = MagicMock()
@@ -19,6 +19,11 @@ def send_code_producer_mock():
 @fixture
 def jwt_service(settings_with_rsa):
     return JWTService(settings_with_rsa)
+
+
+@fixture
+def session_service(cache_adapter, settings_with_rsa):
+    return SessionService(settings_with_rsa, cache_adapter)
 
 
 @fixture

--- a/tests/integration/routers/test_authentication_router_integration.py
+++ b/tests/integration/routers/test_authentication_router_integration.py
@@ -1,12 +1,12 @@
 from starlette.status import HTTP_202_ACCEPTED, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
-from app.core.schemas import AccessCodeCreate, AccessToken, AccessTokenCreate
+from app.core.schemas import AccessCodeCreate, AccessToken, RefreshTokenCreate
 from app.core.services import AccessCodeService
 
 code = "123456"
 access_code_body_1 = AccessCodeCreate(email="email@domain.com", create_user=False)
 access_code_body_2 = AccessCodeCreate(email="anotheremail@domain.com", create_user=True)
-access_token_body = AccessTokenCreate(email="email@domain.com", code=code)
+access_token_body = RefreshTokenCreate(email="email@domain.com", code=code)
 
 
 def generate_access_code_request(client, payload):

--- a/tests/integration/routers/test_authentication_router_integration.py
+++ b/tests/integration/routers/test_authentication_router_integration.py
@@ -1,9 +1,4 @@
-from starlette.status import (
-    HTTP_201_CREATED,
-    HTTP_202_ACCEPTED,
-    HTTP_400_BAD_REQUEST,
-    HTTP_404_NOT_FOUND,
-)
+from starlette.status import HTTP_201_CREATED, HTTP_401_UNAUTHORIZED, HTTP_404_NOT_FOUND
 
 from app.core.schemas import AccessCodeCreate, AccessToken, RefreshTokenCreate
 from app.core.services import AccessCodeService
@@ -49,10 +44,10 @@ def test_generate_access_code_should_send_code_if_user_exists(
 
 
 def generate_access_token_request(client, payload):
-    return client.post("/api/v1/authentication/access-token", json=payload)
+    return client.post("/api/v1/authentication/token", json=payload)
 
 
-def test_generate_access_token_should_return_status_202(
+def test_generate_access_token_should_return_status_201(
     client, cache_adapter, users_repository
 ):
     user = users_repository.create({"email": access_code_body_1.email})
@@ -60,7 +55,7 @@ def test_generate_access_token_should_return_status_202(
         AccessCodeService._get_access_code_key(user.id), 1, code
     )
     response = generate_access_token_request(client, access_token_body.dict())
-    assert response.status_code == HTTP_202_ACCEPTED
+    assert response.status_code == HTTP_201_CREATED
 
 
 def test_generate_access_token_should_return_token(
@@ -84,4 +79,4 @@ def test_generate_access_token_should_return_status_400_if_code_is_invalid(
 ):
     users_repository.create({"email": access_code_body_1.email})
     response = generate_access_token_request(client, access_token_body.dict())
-    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTP_401_UNAUTHORIZED

--- a/tests/integration/routers/test_authentication_router_integration.py
+++ b/tests/integration/routers/test_authentication_router_integration.py
@@ -20,32 +20,32 @@ access_code_body_2 = AccessCodeCreate(email="anotheremail@domain.com", create_us
 access_token_body = RefreshTokenCreate(email="email@domain.com", code=code)
 
 
-def generate_access_code_request(client, payload):
+def send_access_code_request(client, payload):
     return client.post("/api/v1/authentication/code", json=payload)
 
 
-def test_generate_access_code_should_return_status_201(client, users_repository):
+def test_send_access_code_should_return_status_201(client, users_repository):
     users_repository.create({"email": access_code_body_1.email})
-    response = generate_access_code_request(client, access_code_body_1.dict())
+    response = send_access_code_request(client, access_code_body_1.dict())
     assert response.status_code == HTTP_201_CREATED
 
 
-def test_generate_access_code_should_return_status_404_if_user_is_not_found(client):
-    response = generate_access_code_request(client, access_code_body_1.dict())
+def test_send_access_code_should_return_status_404_if_user_is_not_found(client):
+    response = send_access_code_request(client, access_code_body_1.dict())
     assert response.status_code == HTTP_404_NOT_FOUND
 
 
-def test_generate_access_code_should_create_user(client, users_repository):
-    generate_access_code_request(client, access_code_body_2.dict())
+def test_send_access_code_should_create_user(client, users_repository):
+    send_access_code_request(client, access_code_body_2.dict())
     assert len(users_repository.find_all()) == 1
 
 
-def test_generate_access_code_should_send_code_if_user_exists(
+def test_send_access_code_should_send_code_if_user_exists(
     client, send_code_producer_mock, users_repository, cache_client
 ):
     send_code_producer_mock.reset_mock()
     user = users_repository.create({"email": access_code_body_1.email})
-    generate_access_code_request(client, access_code_body_1.dict())
+    send_access_code_request(client, access_code_body_1.dict())
     send_code_producer_mock.send_code.assert_called_once_with(
         cache_client.get(AccessCodeService._get_access_code_key(user.id)).decode(
             "utf-8"
@@ -54,53 +54,53 @@ def test_generate_access_code_should_send_code_if_user_exists(
     )
 
 
-def generate_refresh_token_request(client, payload):
+def create_user_session_request(client, payload):
     return client.post("/api/v1/authentication/token", json=payload)
 
 
-def test_generate_refresh_token_should_return_status_201(
+def test_create_user_session_should_return_status_201(
     client, cache_adapter, users_repository
 ):
     user = users_repository.create({"email": access_code_body_1.email})
     cache_adapter.set_with_expiration(
         AccessCodeService._get_access_code_key(user.id), 1, code
     )
-    response = generate_refresh_token_request(client, access_token_body.dict())
+    response = create_user_session_request(client, access_token_body.dict())
     assert response.status_code == HTTP_201_CREATED
 
 
-def test_generate_refresh_token_should_set_refresh_token_cookie(
+def test_create_user_session_should_set_refresh_token_cookie(
     client, cache_adapter, users_repository
 ):
     user = users_repository.create({"email": access_code_body_1.email})
     cache_adapter.set_with_expiration(
         AccessCodeService._get_access_code_key(user.id), 1, code
     )
-    response = generate_refresh_token_request(client, access_token_body.dict())
+    response = create_user_session_request(client, access_token_body.dict())
     assert response.cookies.get("refresh_token")
 
 
-def test_generate_refresh_token_should_return_access_token(
+def test_create_user_session_should_return_access_token(
     client, cache_adapter, users_repository
 ):
     user = users_repository.create({"email": access_code_body_1.email})
     cache_adapter.set_with_expiration(
         AccessCodeService._get_access_code_key(user.id), 1, code
     )
-    response = generate_refresh_token_request(client, access_token_body.dict())
+    response = create_user_session_request(client, access_token_body.dict())
     assert AccessToken(**response.json())
 
 
-def test_generate_refresh_token_should_return_status_404_if_user_not_found(client):
-    response = generate_refresh_token_request(client, access_token_body.dict())
+def test_create_user_session_should_return_status_404_if_user_not_found(client):
+    response = create_user_session_request(client, access_token_body.dict())
     assert response.status_code == HTTP_404_NOT_FOUND
 
 
-def test_generate_refresh_token_should_return_status_401_if_code_is_invalid(
+def test_create_user_session_should_return_status_401_if_code_is_invalid(
     client, users_repository
 ):
     users_repository.create({"email": access_code_body_1.email})
-    response = generate_refresh_token_request(client, access_token_body.dict())
+    response = create_user_session_request(client, access_token_body.dict())
     assert response.status_code == HTTP_401_UNAUTHORIZED
 
 
@@ -114,30 +114,30 @@ def refresh_token(jwt_service, session_service, settings, users_repository):
     return jwt_service.generate_token(refresh_token_payload.dict())
 
 
-def generate_access_token_request(client, refresh_token):
+def get_fresh_token_request(client, refresh_token):
     headers = {"Cookie": f"refresh_token={refresh_token}"} if refresh_token else {}
     return client.get("/api/v1/authentication/token", headers=headers,)
 
 
-def test_generate_access_token_should_return_status_200(client, refresh_token):
-    response = generate_access_token_request(client, refresh_token)
+def test_get_fresh_token_should_return_status_200(client, refresh_token):
+    response = get_fresh_token_request(client, refresh_token)
     assert response.status_code == HTTP_200_OK
 
 
-def test_generate_access_token_should_return_access_token(client, refresh_token):
-    response = generate_access_token_request(client, refresh_token)
+def test_get_fresh_token_should_return_access_token(client, refresh_token):
+    response = get_fresh_token_request(client, refresh_token)
     assert AccessToken(**response.json())
 
 
-def test_generate_access_token_should_return_unique_token(client, refresh_token):
-    response_1 = generate_access_token_request(client, refresh_token)
+def test_get_fresh_token_should_return_unique_token(client, refresh_token):
+    response_1 = get_fresh_token_request(client, refresh_token)
     token_1 = AccessToken(**response_1.json()).access_token
-    response_2 = generate_access_token_request(client, refresh_token)
+    response_2 = get_fresh_token_request(client, refresh_token)
     token_2 = AccessToken(**response_2.json()).access_token
     assert token_1 != token_2
 
 
-def test_generate_access_token_should_return_status_404_if_user_not_found(
+def test_get_fresh_token_should_return_status_404_if_user_not_found(
     client, jwt_service, session_service, settings
 ):
     session_id = session_service.generate_session(123)
@@ -146,11 +146,11 @@ def test_generate_access_token_should_return_status_404_if_user_not_found(
     )
     refresh_token = jwt_service.generate_token(refresh_token_payload.dict())
 
-    response = generate_access_token_request(client, refresh_token)
+    response = get_fresh_token_request(client, refresh_token)
     assert response.status_code == HTTP_404_NOT_FOUND
 
 
-def test_generate_access_token_should_return_status_401_if_session_is_invalid(
+def test_get_fresh_token_should_return_status_401_if_session_is_invalid(
     client, jwt_service, settings
 ):
     refresh_token_payload = RefreshTokenPayload.from_info(
@@ -158,15 +158,15 @@ def test_generate_access_token_should_return_status_401_if_session_is_invalid(
     )
     refresh_token = jwt_service.generate_token(refresh_token_payload.dict())
 
-    response = generate_access_token_request(client, refresh_token)
+    response = get_fresh_token_request(client, refresh_token)
     assert response.status_code == HTTP_401_UNAUTHORIZED
 
 
-def test_generate_access_token_should_return_401_if_token_is_invalid(client):
-    response = generate_access_token_request(client, "invalid.token")
+def test_get_fresh_token_should_return_401_if_token_is_invalid(client):
+    response = get_fresh_token_request(client, "invalid.token")
     assert response.status_code == HTTP_401_UNAUTHORIZED
 
 
-def test_generate_access_token_should_return_401_if_token_is_missing(client):
-    response = generate_access_token_request(client, None)
+def test_get_fresh_token_should_return_401_if_token_is_missing(client):
+    response = get_fresh_token_request(client, None)
     assert response.status_code == HTTP_401_UNAUTHORIZED

--- a/tests/integration/routers/test_authentication_router_integration.py
+++ b/tests/integration/routers/test_authentication_router_integration.py
@@ -1,4 +1,9 @@
-from starlette.status import HTTP_202_ACCEPTED, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
+from starlette.status import (
+    HTTP_201_CREATED,
+    HTTP_202_ACCEPTED,
+    HTTP_400_BAD_REQUEST,
+    HTTP_404_NOT_FOUND,
+)
 
 from app.core.schemas import AccessCodeCreate, AccessToken, RefreshTokenCreate
 from app.core.services import AccessCodeService
@@ -10,13 +15,13 @@ access_token_body = RefreshTokenCreate(email="email@domain.com", code=code)
 
 
 def generate_access_code_request(client, payload):
-    return client.post("/api/v1/authentication/access-code", json=payload)
+    return client.post("/api/v1/authentication/code", json=payload)
 
 
-def test_generate_access_code_should_return_status_202(client, users_repository):
+def test_generate_access_code_should_return_status_201(client, users_repository):
     users_repository.create({"email": access_code_body_1.email})
     response = generate_access_code_request(client, access_code_body_1.dict())
-    assert response.status_code == HTTP_202_ACCEPTED
+    assert response.status_code == HTTP_201_CREATED
 
 
 def test_generate_access_code_should_return_status_404_if_user_is_not_found(client):

--- a/tests/integration/routers/test_user_current_router_integration.py
+++ b/tests/integration/routers/test_user_current_router_integration.py
@@ -21,7 +21,10 @@ def user(users_repository):
 @fixture
 def user_jwt(jwt_service, user):
     jwt_payload = AccessTokenPayload(
-        user_id=user.id, roles=user.roles, exp=AccessTokenPayload.calc_exp(1)
+        user_id=user.id,
+        roles=user.roles,
+        exp=AccessTokenPayload.calc_exp(1),
+        sid="123456",
     )
     return jwt_service.generate_token(jwt_payload.dict())
 
@@ -58,7 +61,7 @@ def test_read_self_should_return_401_for_invalid_jwt(client):
 
 def test_read_self_should_return_404_if_user_does_not_exist(client, jwt_service):
     jwt_payload = AccessTokenPayload(
-        user_id=1, roles=[], exp=AccessTokenPayload.calc_exp(1)
+        user_id=1, roles=[], exp=AccessTokenPayload.calc_exp(1), sid="123456"
     )
     jwt = jwt_service.generate_token(jwt_payload.dict())
     response = read_self_request(client, jwt)
@@ -106,7 +109,7 @@ def test_update_self_should_return_401_for_invalid_jwt(client):
 
 def test_update_self_should_return_404_if_user_does_not_exist(client, jwt_service):
     jwt_payload = AccessTokenPayload(
-        user_id=1, roles=[], exp=AccessTokenPayload.calc_exp(1)
+        user_id=1, roles=[], exp=AccessTokenPayload.calc_exp(1), sid="123456"
     )
     jwt = jwt_service.generate_token(jwt_payload.dict())
     response = update_self_request(client, jwt)
@@ -118,7 +121,10 @@ def test_update_self_should_return_409_if_data_conflicts(
 ):
     users_repository.create(update_payload)
     jwt_payload = AccessTokenPayload(
-        user_id=user.id, roles=user.roles, exp=AccessTokenPayload.calc_exp(1)
+        user_id=user.id,
+        roles=user.roles,
+        exp=AccessTokenPayload.calc_exp(1),
+        sid="123456",
     )
     jwt = jwt_service.generate_token(jwt_payload.dict())
     response = update_self_request(client, jwt)
@@ -155,7 +161,7 @@ def test_delete_self_should_return_401_for_invalid_jwt(client):
 
 def test_delete_self_should_return_404_if_user_does_not_exist(client, jwt_service):
     jwt_payload = AccessTokenPayload(
-        user_id=1, roles=[], exp=AccessTokenPayload.calc_exp(1)
+        user_id=1, roles=[], exp=AccessTokenPayload.calc_exp(1), sid="123456"
     )
     jwt = jwt_service.generate_token(jwt_payload.dict())
     response = delete_self_request(client, jwt)

--- a/tests/integration/routers/test_user_roles_router_integration.py
+++ b/tests/integration/routers/test_user_roles_router_integration.py
@@ -21,7 +21,10 @@ def user(users_repository):
 @fixture
 def user_jwt(jwt_service, user):
     jwt_payload = AccessTokenPayload(
-        user_id=user.id, roles=user.roles, exp=AccessTokenPayload.calc_exp(1)
+        user_id=user.id,
+        roles=user.roles,
+        exp=AccessTokenPayload.calc_exp(1),
+        sid="123456",
     )
     return jwt_service.generate_token(jwt_payload.dict())
 
@@ -64,7 +67,7 @@ def test_update_user_roles_should_return_401_for_invalid_jwt(client):
 
 def test_update_user_should_return_403_for_non_admin(client, jwt_service):
     jwt_payload = AccessTokenPayload(
-        user_id=1, roles=[], exp=AccessTokenPayload.calc_exp(1)
+        user_id=1, roles=[], exp=AccessTokenPayload.calc_exp(1), sid="123456",
     )
     jwt = jwt_service.generate_token(jwt_payload.dict())
     response = update_user_roles_request(client, 1, jwt, [])
@@ -75,7 +78,10 @@ def test_update_user_roles_should_return_404_if_user_does_not_exist(
     client, jwt_service
 ):
     jwt_payload = AccessTokenPayload(
-        user_id=1, roles=[UserRoles.ADMIN], exp=AccessTokenPayload.calc_exp(1)
+        user_id=1,
+        roles=[UserRoles.ADMIN],
+        exp=AccessTokenPayload.calc_exp(1),
+        sid="123456",
     )
     jwt = jwt_service.generate_token(jwt_payload.dict())
     response = update_user_roles_request(client, 1, jwt, [])

--- a/tests/integration/routers/test_users_router_integration.py
+++ b/tests/integration/routers/test_users_router_integration.py
@@ -26,7 +26,10 @@ def user(users_repository):
 @fixture
 def user_jwt(jwt_service, user):
     jwt_payload = AccessTokenPayload(
-        user_id=user.id, roles=user.roles, exp=AccessTokenPayload.calc_exp(1)
+        user_id=user.id,
+        roles=user.roles,
+        exp=AccessTokenPayload.calc_exp(1),
+        sid="123456",
     )
     return jwt_service.generate_token(jwt_payload.dict())
 
@@ -35,7 +38,10 @@ def user_jwt(jwt_service, user):
 def user_2_jwt(jwt_service, users_repository):
     user = users_repository.create(user_dict_2)
     jwt_payload = AccessTokenPayload(
-        user_id=user.id, roles=user.roles, exp=AccessTokenPayload.calc_exp(1)
+        user_id=user.id,
+        roles=user.roles,
+        exp=AccessTokenPayload.calc_exp(1),
+        sid="123456",
     )
     return jwt_service.generate_token(jwt_payload.dict())
 

--- a/tests/unit/services/test_jwt_service.py
+++ b/tests/unit/services/test_jwt_service.py
@@ -14,7 +14,9 @@ def jwt_service(rsa_keys, settings):
 
 @fixture
 def jwt_payload() -> AccessTokenPayload:
-    return AccessTokenPayload(user_id=123, roles=[], exp=AccessTokenPayload.calc_exp(1))
+    return AccessTokenPayload(
+        user_id=123, roles=[], exp=AccessTokenPayload.calc_exp(1), sid="123456"
+    )
 
 
 @fixture


### PR DESCRIPTION
## What

This PR updates the authentication flow by including a `refresh_token` that is set as cookie when someone validates an access code. The token is then used on another endpoint to retrieve a fresh `access_token`.

This structure allows `access_token`s to be short-lived and only exchanged on requests` headers and payload, while a long-lived `refresh_token` is stored and represents the user's session.